### PR TITLE
PWN-7203 get rid of the `consumer_tag` argument, extract it from topology

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "rust-utils"
-version = "0.10.0"
+version = "0.11.0"
 
 [lib]
 crate-type = ["lib"]

--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+== 0.11.0 ===
+get rid of the `consumer_tag` argument, extract it from topology
 == 0.10.0 ===
 the ethereum module added with EthereumAddress structure for better converting to String type from Address
 === 0.9.0 ===

--- a/src/rabbitmq/message_publisher.rs
+++ b/src/rabbitmq/message_publisher.rs
@@ -50,7 +50,7 @@ impl MessagePublisher for RabbitMessagePublisher {
 #[cfg(feature = "telemetry")]
 #[async_trait]
 impl MessagePublisher for RabbitMessagePublisher {
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, payload))]
     async fn publish_payload(&self, exchange: &str, routing_key: &str, payload: &[u8]) -> anyhow::Result<()> {
         while self.basic_publish(exchange, routing_key, payload).await.is_err() {
             self.reconnect().await?;
@@ -135,7 +135,7 @@ impl RabbitMessagePublisher {
     }
 
     #[cfg(feature = "telemetry")]
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, payload))]
     async fn basic_publish(&self, exchange: &str, routing_key: &str, payload: &[u8]) -> lapin::Result<()> {
         let mut amqp_headers = BTreeMap::new();
 


### PR DESCRIPTION
## Problem

Part of [PWN-7203](https://p2pvalidator.atlassian.net/browse/PWN-7203). Get rid of redundant argument

## Solution

The topology already has all the necessary data.

## Checklist

- [ ] code changes are covered with tests
- [ ] README.md files are up to date
- [ ] CI runs without errors
- [ ] code review passed (at least one other person)