### PR TITLE
Auto ack

### DIFF
--- a/src/rabbitmq/message_publisher.rs
+++ b/src/rabbitmq/message_publisher.rs
@@ -10,9 +10,9 @@ use tokio::sync::RwLock;
 
 #[cfg(feature = "telemetry")]
 use lapin::types::FieldTable;
+use serde::Serialize;
 #[cfg(feature = "telemetry")]
 use std::collections::BTreeMap;
-use serde::Serialize;
 #[cfg(feature = "telemetry")]
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 


### PR DESCRIPTION
The problem is `failed to ack/nack` error leads to reconnection to RabbitMQ, while most times, lapin doesn't even try to communicate with RabbitMQ (most such errors are due to double-nack/double-ack, which is checked in lapin client code without network communication). It leads to dropping good connections and constant reconnections (e.g. 1st nack is in a handler, and 2nd nack is here in `message_consumer`, and it happens all the time).

We have a lot of double acks/nacks because we don't have common responsibility logic: it's unclear who is responsible for acking/nacking.

This patch introduces new logic: all acks/nacks should be done in one place — here, in the library.
And if the handler wants to do ack/nack by itself (e.g. asynchronously), it should return `Ok(false)`.

This way, we guarantee we have only one place to rule all acks/nacks.

The other problem is some errors are permanent (e.g. b/c of some bad message in a queue). If such a bad message appears in a queue, a handler may return an error all the time for the message, and `message_consumer` will always nack on it so that queue processing would be stuck forever. The protocol defines a special marker type, `PermanentError`. Handlers must mark permanent errors with `.context(PermenentError)` to let `message_consumer` know the message is bad and will always be bad, and it should ack the message to let the queue proceed.