### PR TITLE
pin jsonrpsee commit and version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ flexi_logger = { version = "0.22", optional = true }
 futures = { version = "0.3.21", optional = true }
 gcloud-env = { version = "0.1.0", optional = true }
 http = { version = "0.2", optional = true }
-jsonrpsee = { git = "https://github.com/p2p-org/jsonrpsee", features = [
+jsonrpsee = { git = "https://github.com/p2p-org/jsonrpsee", rev = "80ab47c6fc1eefc9c3c77f881405f9a3a58de38c", version = "0.16.2", features = [
   "server",
   "client",
 ], optional = true }


### PR DESCRIPTION
I want to update the version of the `jsonrpsee` library. So I've pinned the current version of `jsonrpsee` for the version comparability.